### PR TITLE
Some small adjustment to the CMakeFile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
 cmake_minimum_required( VERSION 3.7 )
 project( DataDogStatsD VERSION 1.0.0 LANGUAGES CXX )
 
+set( CMAKE_POSITION_INDEPENDENT_CODE ON )
 set( CMAKE_CXX_STANDARD 11 )
+
 set( SOURCE
   DataDogStatsD.cpp
+  DDEvent.cpp
   Helpers.cpp )
+
 include_directories(include)
 
 add_library( ${PROJECT_NAME}_shared SHARED ${SOURCE} )

--- a/DataDogStatsD.cpp
+++ b/DataDogStatsD.cpp
@@ -552,7 +552,11 @@ void DataDogStatsD::flush(string& udp_message)
 		result = ::connect(sock, (SOCKADDR *)&service, sizeof(service));
 		if (result != SOCKET_ERROR)
 		{
-			::send(sock, udp_message.c_str(), udp_message.length(), 0);
+			int bytes_written= ::send(sock, udp_message.c_str(), udp_message.length(), 0);
+			// What to do if the message wasn't fully sent?
+			if (bytes_written < (int)udp_message.length()) {
+			}
+
 			closesocket(sock);
 			WSACleanup();
 		}
@@ -573,7 +577,10 @@ void DataDogStatsD::flush(string& udp_message)
 
 	connect(udp_socket, (struct sockaddr *) &serv_addr, sizeof(serv_addr));
 
-	write(udp_socket, udp_message.c_str(), udp_message.length());
+	ssize_t bytes_written= write(udp_socket, udp_message.c_str(), udp_message.length());
+	// What to do if the message wasn't fully sent?
+	if (bytes_written < (ssize_t)udp_message.length()) {
+	}
 
 	close(udp_socket);
 #endif


### PR DESCRIPTION
I was trying to statically link this project into a logging library we have. My goal was not to expose all the dependencies like rapidjson, curl, etc to the logging consumers. 

What I noticed was the following building on linux:
1. The DDEvent.cpp was part of the source in the CMakeFile.txt
2. Some VVT (virtual table address) issues when linking into a shared library.
```
/usr/bin/ld: /usr/local/lib/libDataDogStatsD.a(DataDogStatsD.cpp.o): relocation R_X86_64_PC32 against symbol `_ZNSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS5_EEC1Ev' can not be used when making a shared object; recompile with -fPIC
```
3. Warning message when building DataDogStatsD.cpp due to the "attribute warn_unused_result" compiler flag.
```
/cpp_build_root/cpp-datadogstatsd/DataDogStatsD.cpp: In member function 'void DataDogStatsD::flush(std::__cxx11::string&)':
/cpp_build_root/cpp-datadogstatsd/DataDogStatsD.cpp:576:7: warning: ignoring return value of 'ssize_t write(int, const void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]
  write(udp_socket, udp_message.c_str(), udp_message.length());
```

The following changes was made to resolve the above:
1.  Added DDEvent.cpp to the source list.
2. Added the `set( CMAKE_POSITION_INDEPENDENT_CODE ON )` to add the -fpic on supported platforms.
3. Captured the return value from `send` and added some placeholder code. I think this is easier than messing with compiler flags.

Let me know what you all think, 
-- Anders
